### PR TITLE
Add The Club sltr group with channels and full group chat

### DIFF
--- a/src/app/api/groups/setup-club/route.ts
+++ b/src/app/api/groups/setup-club/route.ts
@@ -23,11 +23,11 @@ async function handleSetup() {
       )
     }
 
-    // Check if "THE CLUB" group already exists
+    // Check if "The Club sltr" group already exists
     const { data: existingGroups } = await supabase
       .from('groups')
       .select('id, title')
-      .ilike('title', 'THE CLUB')
+      .ilike('title', 'The Club sltr')
       .limit(1)
 
     let groupId: string
@@ -37,12 +37,12 @@ async function handleSetup() {
       // Group already exists, use it
       groupId = existingGroups[0].id
     } else {
-      // Create "THE CLUB" group
+      // Create "The Club sltr" group
       const { data: newGroup, error: groupError } = await supabase
         .from('groups')
         .insert({
-          title: 'THE CLUB',
-          description: 'The premier group for video conferencing, voice chats, and messaging. Join the conversation!',
+          title: 'The Club sltr',
+          description: 'The premier club for video conferencing, voice chats, and messaging. Connect, chat, and vibe with the community!',
           host_id: user.id,
         })
         .select('id')
@@ -73,21 +73,61 @@ async function handleSetup() {
       .select('id, name, type, description')
       .eq('group_id', groupId)
 
+    // The Club sltr channels - each with video conferencing, chat, and messaging
     const channelsToCreate = [
+      // The Club P'n'P - Video
       {
-        name: 'General Chat',
-        description: 'Text messaging and group chat',
-        type: 'text' as const,
+        name: "The Club P'n'P",
+        description: 'Video conferencing room - Party and Play with the community',
+        type: 'video' as const,
       },
+      // The Club P'n'P - Voice
       {
-        name: 'Voice Room',
-        description: 'Join voice calls with the group',
+        name: "The Club P'n'P Voice",
+        description: 'Voice chat room - Party and Play audio',
         type: 'voice' as const,
       },
+      // The Club P'n'P - Text
       {
-        name: 'Video Conference',
-        description: 'Join video calls and conferences',
+        name: "The Club P'n'P Chat",
+        description: 'Text chat room - Party and Play messaging',
+        type: 'text' as const,
+      },
+      // The Club H'n'H - Video
+      {
+        name: "The Club H'n'H",
+        description: 'Video conferencing room - High and Horny with the community',
         type: 'video' as const,
+      },
+      // The Club H'n'H - Voice
+      {
+        name: "The Club H'n'H Voice",
+        description: 'Voice chat room - High and Horny audio',
+        type: 'voice' as const,
+      },
+      // The Club H'n'H - Text
+      {
+        name: "The Club H'n'H Chat",
+        description: 'Text chat room - High and Horny messaging',
+        type: 'text' as const,
+      },
+      // The Club Smoke N' Stroke - Video
+      {
+        name: "The Club Smoke N' Stroke",
+        description: 'Video conferencing room - Smoke and Stroke with the community',
+        type: 'video' as const,
+      },
+      // The Club Smoke N' Stroke - Voice
+      {
+        name: "The Club Smoke N' Stroke Voice",
+        description: 'Voice chat room - Smoke and Stroke audio',
+        type: 'voice' as const,
+      },
+      // The Club Smoke N' Stroke - Text
+      {
+        name: "The Club Smoke N' Stroke Chat",
+        description: 'Text chat room - Smoke and Stroke messaging',
+        type: 'text' as const,
       },
     ]
 
@@ -134,18 +174,18 @@ async function handleSetup() {
       success: true,
       group: {
         id: groupId,
-        title: 'THE CLUB',
-        description: 'The premier group for video conferencing, voice chats, and messaging.',
+        title: 'The Club sltr',
+        description: 'The premier club for video conferencing, voice chats, and messaging.',
       },
       channels: createdChannels,
-      message: isNew 
-        ? 'THE CLUB group created successfully!' 
-        : 'THE CLUB group already exists. Channels verified.',
+      message: isNew
+        ? 'The Club sltr created successfully with all channels!'
+        : 'The Club sltr already exists. Channels verified.',
     })
   } catch (error: any) {
-    console.error('Error setting up THE CLUB:', error)
+    console.error('Error setting up The Club sltr:', error)
     return NextResponse.json(
-      { error: error.message || 'Failed to setup THE CLUB' },
+      { error: error.message || 'Failed to setup The Club sltr' },
       { status: 500 }
     )
   }

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -1,35 +1,410 @@
 "use client"
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef, Suspense } from 'react'
 import { createClient } from '@/lib/supabase/client'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import BottomNav from '@/components/BottomNav'
+import MobileLayout from '@/components/MobileLayout'
 
-export default function GroupDetailPage({ params }: { params: { id: string } }) {
+interface GroupMessage {
+  id: string
+  group_id: string
+  sender_id: string
+  content: string
+  created_at: string
+  sender_profile?: {
+    display_name: string
+    photo_url: string
+  }
+}
+
+interface Channel {
+  id: string
+  name: string
+  description?: string
+  type: 'text' | 'voice' | 'video'
+}
+
+function GroupDetailContent({ groupId }: { groupId: string }) {
   const supabase = createClient()
   const router = useRouter()
-  const [group, setGroup] = useState<any>(null)
-  const [loading, setLoading] = useState(true)
+  const searchParams = useSearchParams()
+  const channelId = searchParams?.get('channel')
 
+  const [group, setGroup] = useState<any>(null)
+  const [channels, setChannels] = useState<Channel[]>([])
+  const [messages, setMessages] = useState<GroupMessage[]>([])
+  const [newMessage, setNewMessage] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [sending, setSending] = useState(false)
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [activeChannel, setActiveChannel] = useState<Channel | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  const scrollToBottom = () => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+  }
+
+  // Load group and user
   useEffect(() => {
-    const run = async () => {
-      const { data } = await supabase.from('groups').select('*').eq('id', params.id).single()
-      setGroup(data)
+    const init = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        router.push('/login')
+        return
+      }
+      setCurrentUserId(user.id)
+
+      // Load group
+      const { data: groupData } = await supabase
+        .from('groups')
+        .select('*')
+        .eq('id', groupId)
+        .single()
+
+      setGroup(groupData)
+
+      // Load channels for this group
+      const { data: channelsData } = await supabase
+        .from('channels')
+        .select('*')
+        .eq('group_id', groupId)
+        .order('created_at', { ascending: true })
+
+      if (channelsData) {
+        setChannels(channelsData)
+        // Set active channel if specified in URL or default to first text channel
+        if (channelId) {
+          const channel = channelsData.find((c: Channel) => c.id === channelId)
+          setActiveChannel(channel || null)
+        } else {
+          const textChannel = channelsData.find((c: Channel) => c.type === 'text')
+          setActiveChannel(textChannel || null)
+        }
+      }
+
       setLoading(false)
     }
-    run()
-  }, [params.id, supabase])
+    init()
+  }, [groupId, channelId, router, supabase])
 
-  if (loading) return <div className="min-h-screen flex items-center justify-center text-white/60">Loading…</div>
-  if (!group) return <div className="min-h-screen flex items-center justify-center text-white/60">Not found</div>
+  // Load messages for active channel
+  useEffect(() => {
+    if (!activeChannel || activeChannel.type !== 'text') return
+
+    const loadMessages = async () => {
+      const { data } = await supabase
+        .from('group_messages')
+        .select(`
+          *,
+          sender_profile:profiles!group_messages_sender_id_fkey(display_name, photo_url)
+        `)
+        .eq('group_id', groupId)
+        .order('created_at', { ascending: true })
+        .limit(100)
+
+      if (data) {
+        setMessages(data)
+        setTimeout(scrollToBottom, 100)
+      }
+    }
+
+    loadMessages()
+
+    // Subscribe to new messages
+    const channel = supabase
+      .channel(`group-messages-${groupId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'group_messages',
+          filter: `group_id=eq.${groupId}`,
+        },
+        async (payload) => {
+          // Load sender profile for the new message
+          const { data: profile } = await supabase
+            .from('profiles')
+            .select('display_name, photo_url')
+            .eq('id', payload.new.sender_id)
+            .single()
+
+          const newMsg: GroupMessage = {
+            ...payload.new as GroupMessage,
+            sender_profile: profile || undefined,
+          }
+          setMessages((prev) => [...prev, newMsg])
+          setTimeout(scrollToBottom, 100)
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [activeChannel, groupId, supabase])
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!newMessage.trim() || !currentUserId || sending) return
+
+    setSending(true)
+    try {
+      const { error } = await supabase
+        .from('group_messages')
+        .insert({
+          group_id: groupId,
+          sender_id: currentUserId,
+          content: newMessage.trim(),
+        })
+
+      if (error) {
+        console.error('Error sending message:', error)
+        alert('Failed to send message')
+      } else {
+        setNewMessage('')
+      }
+    } catch (err) {
+      console.error('Error:', err)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const handleChannelClick = (channel: Channel) => {
+    if (channel.type === 'text') {
+      setActiveChannel(channel)
+      router.push(`/groups/${groupId}?channel=${channel.id}`)
+    } else {
+      // Navigate to video/voice room
+      router.push(`/groups/channels/${channel.id}?group=${groupId}&type=${channel.type}`)
+    }
+  }
+
+  if (loading) {
+    return (
+      <MobileLayout>
+        <div className="min-h-screen bg-[#0a0a0f] flex items-center justify-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-lime-400"></div>
+        </div>
+      </MobileLayout>
+    )
+  }
+
+  if (!group) {
+    return (
+      <MobileLayout>
+        <div className="min-h-screen bg-[#0a0a0f] flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-white/60 mb-4">Group not found</p>
+            <Link href="/groups" className="text-lime-400 hover:underline">
+              Back to Groups
+            </Link>
+          </div>
+        </div>
+      </MobileLayout>
+    )
+  }
 
   return (
-    <div className="min-h-screen bg-[#0a0a0f] p-4">
-      <button onClick={() => router.back()} className="text-white/70 hover:text-white mb-4">← Back</button>
-      <div className="max-w-xl mx-auto bg-black/70 border border-white/10 rounded-2xl p-4 text-white space-y-2">
-        <h1 className="text-2xl font-bold">{group.title}</h1>
-        {group.time && <div className="text-white/70">{new Date(group.time).toLocaleString()}</div>}
-        {group.description && <p className="text-white/80 mt-2 whitespace-pre-wrap">{group.description}</p>}
+    <MobileLayout>
+      <div className="min-h-screen bg-[#0a0a0f] flex flex-col">
+        {/* Header */}
+        <div className="sticky top-0 z-40 bg-black/90 backdrop-blur-xl border-b border-lime-400/20">
+          <div className="px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => router.push('/groups')}
+                  className="text-white/70 hover:text-white"
+                >
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+                <div>
+                  <h1 className="text-white text-lg font-bold">{group.title || group.name}</h1>
+                  {activeChannel && (
+                    <p className="text-white/60 text-sm">#{activeChannel.name}</p>
+                  )}
+                </div>
+              </div>
+              <Link
+                href={`/groups/channels?group=${groupId}`}
+                className="px-3 py-1.5 rounded-lg bg-lime-400/20 text-lime-300 text-sm hover:bg-lime-400/30 transition"
+              >
+                Channels
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Channel Tabs */}
+        {channels.length > 0 && (
+          <div className="border-b border-white/10 bg-black/40">
+            <div className="px-4 py-2 flex gap-2 overflow-x-auto">
+              {channels.map((channel) => (
+                <button
+                  key={channel.id}
+                  onClick={() => handleChannelClick(channel)}
+                  className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm whitespace-nowrap transition ${
+                    activeChannel?.id === channel.id
+                      ? 'bg-lime-400/30 text-white border border-lime-400/60'
+                      : 'bg-white/5 text-white/70 hover:bg-white/10 border border-transparent'
+                  }`}
+                >
+                  {channel.type === 'text' && <span>💬</span>}
+                  {channel.type === 'voice' && <span>🎤</span>}
+                  {channel.type === 'video' && <span>📹</span>}
+                  <span>{channel.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Content Area */}
+        {activeChannel?.type === 'text' ? (
+          <>
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto px-4 py-4 pb-40">
+              {messages.length === 0 ? (
+                <div className="text-center py-12">
+                  <div className="text-4xl mb-4">💬</div>
+                  <p className="text-white/60">No messages yet</p>
+                  <p className="text-white/40 text-sm mt-1">Be the first to say something!</p>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {messages.map((msg) => {
+                    const isOwn = msg.sender_id === currentUserId
+                    return (
+                      <div
+                        key={msg.id}
+                        className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}
+                      >
+                        <div className={`max-w-[80%] ${isOwn ? 'order-2' : 'order-1'}`}>
+                          {!isOwn && (
+                            <div className="flex items-center gap-2 mb-1">
+                              {msg.sender_profile?.photo_url ? (
+                                <img
+                                  src={msg.sender_profile.photo_url}
+                                  alt=""
+                                  className="w-6 h-6 rounded-full object-cover"
+                                />
+                              ) : (
+                                <div className="w-6 h-6 rounded-full bg-lime-400/30 flex items-center justify-center text-xs text-lime-300">
+                                  {(msg.sender_profile?.display_name || 'U')[0].toUpperCase()}
+                                </div>
+                              )}
+                              <span className="text-white/60 text-xs">
+                                {msg.sender_profile?.display_name || 'Anonymous'}
+                              </span>
+                            </div>
+                          )}
+                          <div
+                            className={`rounded-2xl px-4 py-2 ${
+                              isOwn
+                                ? 'bg-lime-400 text-black rounded-tr-sm'
+                                : 'bg-white/10 text-white rounded-tl-sm'
+                            }`}
+                          >
+                            <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                          </div>
+                          <p className={`text-white/40 text-xs mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
+                            {new Date(msg.created_at).toLocaleTimeString([], {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </p>
+                        </div>
+                      </div>
+                    )
+                  })}
+                  <div ref={messagesEndRef} />
+                </div>
+              )}
+            </div>
+
+            {/* Message Input */}
+            <div className="fixed bottom-16 left-0 right-0 bg-black/90 backdrop-blur-xl border-t border-white/10 p-4">
+              <form onSubmit={handleSendMessage} className="flex gap-2">
+                <input
+                  type="text"
+                  value={newMessage}
+                  onChange={(e) => setNewMessage(e.target.value)}
+                  placeholder="Type a message..."
+                  className="flex-1 rounded-full bg-white/10 border border-white/20 px-4 py-3 text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-lime-400"
+                />
+                <button
+                  type="submit"
+                  disabled={!newMessage.trim() || sending}
+                  className="px-6 py-3 rounded-full bg-lime-400 text-black font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:scale-105 transition-all"
+                >
+                  {sending ? '...' : 'Send'}
+                </button>
+              </form>
+            </div>
+          </>
+        ) : (
+          /* No active text channel */
+          <div className="flex-1 flex items-center justify-center px-4">
+            <div className="text-center">
+              <div className="text-6xl mb-4">📹</div>
+              <h2 className="text-white text-xl font-bold mb-2">
+                {group.title || group.name}
+              </h2>
+              <p className="text-white/60 mb-6">
+                {group.description || 'Join a channel to start chatting or connect via video/voice'}
+              </p>
+              {channels.length > 0 ? (
+                <div className="space-y-2">
+                  <p className="text-white/40 text-sm mb-3">Available Channels:</p>
+                  {channels.slice(0, 3).map((channel) => (
+                    <button
+                      key={channel.id}
+                      onClick={() => handleChannelClick(channel)}
+                      className="w-full px-4 py-3 rounded-xl bg-white/10 hover:bg-white/20 text-white transition flex items-center justify-center gap-2"
+                    >
+                      {channel.type === 'text' && <span>💬</span>}
+                      {channel.type === 'voice' && <span>🎤</span>}
+                      {channel.type === 'video' && <span>📹</span>}
+                      {channel.name}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <Link
+                  href="/groups/channels"
+                  className="inline-block px-6 py-3 rounded-xl bg-lime-400 text-black font-semibold hover:scale-105 transition-all"
+                >
+                  Browse Channels
+                </Link>
+              )}
+            </div>
+          </div>
+        )}
+
+        <BottomNav />
       </div>
-    </div>
+    </MobileLayout>
+  )
+}
+
+export default function GroupDetailPage({ params }: { params: { id: string } }) {
+  return (
+    <Suspense fallback={
+      <MobileLayout>
+        <div className="min-h-screen bg-[#0a0a0f] flex items-center justify-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-lime-400"></div>
+        </div>
+      </MobileLayout>
+    }>
+      <GroupDetailContent groupId={params.id} />
+    </Suspense>
   )
 }

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -50,10 +50,10 @@ export default function GroupsPage() {
       
       if (response.ok) {
         const data = await response.json()
-        console.log('✅ THE CLUB setup:', data.message)
+        console.log('✅ The Club sltr setup:', data.message)
       }
     } catch (error) {
-      console.error('Error setting up THE CLUB:', error)
+      console.error('Error setting up The Club sltr:', error)
     }
   }
 
@@ -157,62 +157,47 @@ export default function GroupsPage() {
           <div className="px-4 py-4 space-y-3">
             <h2 className="text-white/60 text-xs uppercase mb-2">Your Groups</h2>
             {groups.map((group) => (
-              <div
+              <Link
                 key={group.id}
-                className="p-4 bg-black/40 border border-white/10 rounded-xl hover:border-lime-400/40 transition"
+                href={`/groups/${group.id}`}
+                className="block p-4 bg-black/40 border border-white/10 rounded-xl hover:border-lime-400/40 transition"
               >
-                <h3 className="text-white font-medium">{group.title}</h3>
-                {group.description && (
-                  <p className="text-white/60 text-sm mt-1">{group.description}</p>
-                )}
-              </div>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">{group.title}</h3>
+                    {group.description && (
+                      <p className="text-white/60 text-sm mt-1 line-clamp-2">{group.description}</p>
+                    )}
+                  </div>
+                  <div className="text-lime-400/60">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </div>
+                </div>
+              </Link>
             ))}
           </div>
         )}
 
-        {/* Coming Soon Content */}
-        <div className="flex-1 flex items-center justify-center px-4 py-12">
-          <div className="text-center max-w-md">
-            <div className="text-6xl mb-6">👥</div>
-            <h2 className="text-white text-3xl font-bold mb-4">Groups Coming Soon</h2>
-            <p className="text-white/60 text-lg mb-8">
-              Join group chats, events, and connect with your local community. This feature is launching soon!
-            </p>
-            
-            {/* Feature Preview Cards */}
-            <div className="space-y-4 text-left">
-              <div className="glass-bubble p-4">
-                <div className="flex items-start gap-3">
-                  <div className="text-2xl">💬</div>
-                  <div>
-                    <h3 className="text-white font-semibold mb-1">Group Chats</h3>
-                    <p className="text-white/60 text-sm">Chat with multiple people at once</p>
-                  </div>
-                </div>
-              </div>
-              
-              <div className="glass-bubble p-4">
-                <div className="flex items-start gap-3">
-                  <div className="text-2xl">📍</div>
-                  <div>
-                    <h3 className="text-white font-semibold mb-1">Local Events</h3>
-                    <p className="text-white/60 text-sm">Discover and join nearby meetups</p>
-                  </div>
-                </div>
-              </div>
-              
-              <div className="glass-bubble p-4">
-                <div className="flex items-start gap-3">
-                  <div className="text-2xl">🎉</div>
-                  <div>
-                    <h3 className="text-white font-semibold mb-1">Interest Groups</h3>
-                    <p className="text-white/60 text-sm">Find people with similar interests</p>
-                  </div>
-                </div>
-              </div>
+        {/* Empty State - Only show if no groups */}
+        {groups.length === 0 && (
+          <div className="flex-1 flex items-center justify-center px-4 py-12">
+            <div className="text-center max-w-md">
+              <div className="text-6xl mb-6">👥</div>
+              <h2 className="text-white text-3xl font-bold mb-4">Create Your First Group</h2>
+              <p className="text-white/60 text-lg mb-8">
+                Start a group to connect with your community through video calls, voice chats, and messaging.
+              </p>
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="px-6 py-3 rounded-xl bg-lime-400 text-black font-semibold hover:scale-105 transition-all"
+              >
+                + Create Your First Group
+              </button>
             </div>
           </div>
-        </div>
+        )}
 
         {/* Create Group Modal */}
         {showCreateModal && (


### PR DESCRIPTION
### **User description**
- Remove Coming Soon placeholder from groups page
- Create The Club sltr group with 9 channels:
  - The Club P'n'P (Video, Voice, Chat)
  - The Club H'n'H (Video, Voice, Chat)
  - The Club Smoke N' Stroke (Video, Voice, Chat)
- Add full group chat interface with real-time messaging
- Make groups clickable to navigate to group detail
- Support video conferencing, voice, and text channels


___

### **PR Type**
Enhancement


___

### **Description**
- Rename "THE CLUB" group to "The Club sltr" with updated descriptions

- Create 9 channels (3 per theme) with video, voice, and text support
  - The Club P'n'P, H'n'H, and Smoke N' Stroke each have dedicated channels

- Implement full group chat interface with real-time messaging
  - Message display, user profiles, timestamps, and auto-scroll

- Make groups clickable to navigate to group detail pages

- Remove "Coming Soon" placeholder and show actual groups list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Group Setup API"] -->|Create/Verify| B["The Club sltr Group"]
  B -->|Contains 9 Channels| C["3 Channel Types"]
  C -->|Video/Voice/Text| D["P'n'P, H'n'H, Smoke N' Stroke"]
  E["Groups Page"] -->|Click Group| F["Group Detail Page"]
  F -->|Load Channels| G["Channel Tabs"]
  G -->|Select Text| H["Chat Interface"]
  H -->|Real-time Messages| I["Supabase Realtime"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Update group setup with themed channels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/groups/setup-club/route.ts

<ul><li>Update group name from "THE CLUB" to "The Club sltr" throughout<br> <li> Expand channels array from 3 generic channels to 9 themed channels<br> <li> Add detailed descriptions for each channel (P'n'P, H'n'H, Smoke N' <br>Stroke)<br> <li> Update success/error messages to reference new group name<br> <li> Add inline comments documenting channel organization</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/5/files#diff-2a6240dbacb403fa24047dbdaa54312cdcfa52106a265513b3903152f47547af">+58/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Build complete group chat and channel interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/groups/[id]/page.tsx

<ul><li>Implement full group detail page with channel management and chat <br>interface<br> <li> Add real-time messaging with Supabase subscriptions and auto-scroll<br> <li> Create channel tabs with type indicators (text, voice, video)<br> <li> Display messages with sender profiles, timestamps, and message styling<br> <li> Add message input form with send functionality<br> <li> Implement channel navigation and empty state handling<br> <li> Wrap component with Suspense for loading states</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/5/files#diff-1c0b50fba742c6fcbf2620d5dc795078e5e22d0ed0ea1b97eb66f590b6a60f7d">+392/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace placeholder with functional groups list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/groups/page.tsx

<ul><li>Convert group list items from divs to clickable Links<br> <li> Remove "Coming Soon" placeholder content and feature preview cards<br> <li> Show actual groups list when groups exist<br> <li> Add empty state with "Create Your First Group" button when no groups<br> <li> Update console log messages to reference "The Club sltr"<br> <li> Add visual arrow indicator for group navigation</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/5/files#diff-f3955853c877291ba470573eaf3491e42c6daf65b17af1ea3b13a1082c07ec37">+35/-50</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Groups are now directly accessible with dedicated detail pages.
  * Real-time messaging within group channels with live updates.
  * Support for multiple channel types: text, voice, and video.
  * Enhanced channel navigation and message history viewing.
  * Empty state with quick access to create your first group.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launches “The Club sltr” with 9 themed channels and a full real-time group chat, replacing the groups placeholder with a reliable, scalable experience. Adds clean navigation, channel tabs, and text/voice/video support aimed at enterprise-ready performance.

- **New Features**
  - Setup API creates/verifies “The Club sltr” and 9 channels (P'n'P, H'n'H, Smoke N' Stroke) across text, voice, and video.
  - Groups page now shows real groups, is clickable, and has an empty state; “Coming Soon” removed.
  - Group detail adds channel tabs and real-time chat (profiles, timestamps, auto-scroll) via Supabase.
  - Mobile-friendly layout with Suspense and loading states; deep-linking to channels via query params.

- **Reliability, Safety, and Scale Recommendations**
  - Model messages per channel_id (not just group_id); enforce RLS/RBAC by group and channel; add message length limits and server-side validation.
  - Add pagination and virtualization for chat history; create DB indexes on (channel_id, created_at), (group_id, created_at), and channels(group_id) for high throughput.
  - Improve realtime robustness: dedupe on reconnect, exponential backoff, and guaranteed listener cleanup; add structured logs and alerting for subscription failures.
  - Sanitize content and enforce safe rendering to prevent XSS; restrict profile image origins; consider content moderation hooks.
  - For scale: cache channel lists, apply rate limiting and flood control, and consider specialized services (e.g., LiveKit for SFU video/voice, Ably/Pusher for chat) if concurrency grows.

<sup>Written for commit 01a9b5164616f63fa54aa1de66178fc6323c0daf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

