### PR TITLE
🐛 Fix groups table schema conflicts

### DIFF
--- a/fix_groups_schema_NOW.sql
+++ b/fix_groups_schema_NOW.sql
@@ -1,0 +1,102 @@
+-- ⚡ IMMEDIATE FIX FOR GROUPS TABLE SCHEMA
+-- Copy and paste this entire file into Supabase Dashboard > SQL Editor > New Query
+-- Then click "Run" to apply the fix
+
+-- Step 1: Fix column naming issues
+DO $$
+BEGIN
+  -- If table has 'title' instead of 'name', rename it
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'title'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'name'
+  ) THEN
+    ALTER TABLE public.groups RENAME COLUMN title TO name;
+    RAISE NOTICE '✅ Renamed title to name';
+  END IF;
+
+  -- Ensure 'name' column exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'name'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN name TEXT NOT NULL DEFAULT '';
+    RAISE NOTICE '✅ Added name column';
+  END IF;
+
+  -- Ensure 'host_id' exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'host_id'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN host_id UUID;
+    ALTER TABLE public.groups ADD CONSTRAINT groups_host_id_fkey
+      FOREIGN KEY (host_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+    RAISE NOTICE '✅ Added host_id column';
+  END IF;
+
+  -- Copy owner_id to host_id if needed
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'owner_id'
+  ) THEN
+    UPDATE public.groups SET host_id = owner_id WHERE host_id IS NULL;
+    RAISE NOTICE '✅ Copied owner_id to host_id';
+  END IF;
+
+  -- Ensure created_at exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'created_at'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+    RAISE NOTICE '✅ Added created_at column';
+  END IF;
+
+  -- Remove 'time' column if it exists (wrong schema)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'groups' AND column_name = 'time'
+  ) THEN
+    ALTER TABLE public.groups DROP COLUMN time;
+    RAISE NOTICE '✅ Removed time column';
+  END IF;
+END $$;
+
+-- Step 2: Fix trigger to work with both owner_id and host_id
+CREATE OR REPLACE FUNCTION public.add_group_owner()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.group_members (group_id, user_id, role)
+  VALUES (NEW.id, COALESCE(NEW.host_id, NEW.owner_id), 'owner')
+  ON CONFLICT (group_id, user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_group_created ON public.groups;
+CREATE TRIGGER on_group_created
+  AFTER INSERT ON public.groups
+  FOR EACH ROW
+  EXECUTE FUNCTION public.add_group_owner();
+
+-- Step 3: Update RLS policies to work with both schemas
+DROP POLICY IF EXISTS "groups_insert_auth" ON public.groups;
+CREATE POLICY "groups_insert_auth" ON public.groups
+  FOR INSERT WITH CHECK (auth.uid() = COALESCE(host_id, owner_id));
+
+DROP POLICY IF EXISTS "groups_update_owner" ON public.groups;
+CREATE POLICY "groups_update_owner" ON public.groups
+  FOR UPDATE USING (auth.uid() = COALESCE(host_id, owner_id));
+
+DROP POLICY IF EXISTS "groups_delete_owner" ON public.groups;
+CREATE POLICY "groups_delete_owner" ON public.groups
+  FOR DELETE USING (auth.uid() = COALESCE(host_id, owner_id));
+
+DROP POLICY IF EXISTS "groups_select_all" ON public.groups;
+CREATE POLICY "groups_select_all" ON public.groups
+  FOR SELECT USING (true);
+
+-- ✅ DONE! You should now be able to create groups without errors.

--- a/supabase/migrations/20251128_fix_groups_schema.sql
+++ b/supabase/migrations/20251128_fix_groups_schema.sql
@@ -1,0 +1,119 @@
+-- Migration: Fix groups table schema conflicts
+-- This ensures the groups table has the correct columns that the app expects
+
+-- Drop the problematic groups table if it has the wrong schema
+-- and recreate with the correct one
+DO $$
+BEGIN
+  -- Check if groups table has 'title' instead of 'name'
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'title'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'name'
+  ) THEN
+    -- Rename 'title' to 'name' if 'name' doesn't exist
+    ALTER TABLE public.groups RENAME COLUMN title TO name;
+  END IF;
+
+  -- Ensure 'name' column exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'name'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN name TEXT NOT NULL DEFAULT '';
+  END IF;
+
+  -- Ensure 'host_id' column exists (added by 20251103 migration)
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'host_id'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN host_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+  END IF;
+
+  -- If owner_id exists but host_id doesn't have values, copy them over
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'owner_id'
+  ) THEN
+    -- Copy owner_id to host_id where host_id is null
+    UPDATE public.groups SET host_id = owner_id WHERE host_id IS NULL;
+  END IF;
+
+  -- Ensure created_at exists with default
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'created_at'
+  ) THEN
+    ALTER TABLE public.groups ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+  END IF;
+
+  -- Remove the 'time' column if it exists (from wrong schema)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'groups'
+    AND column_name = 'time'
+  ) THEN
+    ALTER TABLE public.groups DROP COLUMN time;
+  END IF;
+
+END $$;
+
+-- Update the trigger to use host_id instead of owner_id
+-- (or create it if it doesn't exist)
+CREATE OR REPLACE FUNCTION public.add_group_owner()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Use host_id (new schema) or owner_id (old schema) depending on which is set
+  INSERT INTO public.group_members (group_id, user_id, role)
+  VALUES (NEW.id, COALESCE(NEW.host_id, NEW.owner_id), 'owner')
+  ON CONFLICT (group_id, user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Ensure the trigger exists
+DROP TRIGGER IF EXISTS on_group_created ON public.groups;
+CREATE TRIGGER on_group_created
+  AFTER INSERT ON public.groups
+  FOR EACH ROW
+  EXECUTE FUNCTION public.add_group_owner();
+
+-- Update policies to work with both host_id and owner_id for compatibility
+DROP POLICY IF EXISTS "groups_insert_auth" ON public.groups;
+CREATE POLICY "groups_insert_auth" ON public.groups
+  FOR INSERT WITH CHECK (
+    auth.uid() = COALESCE(host_id, owner_id)
+  );
+
+DROP POLICY IF EXISTS "groups_update_owner" ON public.groups;
+CREATE POLICY "groups_update_owner" ON public.groups
+  FOR UPDATE USING (
+    auth.uid() = COALESCE(host_id, owner_id)
+  );
+
+DROP POLICY IF EXISTS "groups_delete_owner" ON public.groups;
+CREATE POLICY "groups_delete_owner" ON public.groups
+  FOR DELETE USING (
+    auth.uid() = COALESCE(host_id, owner_id)
+  );
+
+-- Ensure groups table is visible (keep existing select policies but make them work)
+DROP POLICY IF EXISTS "groups_select_all" ON public.groups;
+CREATE POLICY "groups_select_all" ON public.groups
+  FOR SELECT USING (true);


### PR DESCRIPTION
### **User description**
- Add migration to fix conflicting groups schemas
- Rename 'title' to 'name' for consistency with app code
- Ensure both host_id and owner_id work for compatibility
- Fix trigger to handle both column names
- Update RLS policies
- Add standalone SQL fix for immediate deployment


___

### **PR Type**
Bug fix


___

### **Description**
- Fix groups table schema conflicts by renaming 'title' to 'name'

- Add missing 'host_id' column with backward compatibility for 'owner_id'

- Update trigger and RLS policies to handle both column names

- Provide standalone SQL script for immediate deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Groups Table<br/>Schema Issues"] -->|Rename| B["'title' → 'name'"]
  A -->|Add Missing| C["'host_id' Column"]
  A -->|Copy Data| D["owner_id → host_id"]
  B --> E["Update Trigger<br/>add_group_owner"]
  C --> E
  D --> E
  E --> F["Update RLS Policies<br/>COALESCE host_id/owner_id"]
  F --> G["✅ Schema Fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fix_groups_schema_NOW.sql</strong><dd><code>Immediate fix script for groups schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fix_groups_schema_NOW.sql

<ul><li>Standalone SQL script for immediate deployment via Supabase Dashboard<br> <li> Conditionally renames 'title' to 'name' if needed<br> <li> Adds missing 'host_id' column with foreign key constraint<br> <li> Copies existing 'owner_id' values to 'host_id' for data migration<br> <li> Updates trigger function to use COALESCE for backward compatibility<br> <li> Recreates RLS policies to work with both column names</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/12/files#diff-eb25159485d16a1a5d23f24cfd14c2734745983087c2cf03b26b5c9cf8a48c14">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20251128_fix_groups_schema.sql</strong><dd><code>Database migration for groups schema normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supabase/migrations/20251128_fix_groups_schema.sql

<ul><li>Database migration to fix groups table schema conflicts<br> <li> Conditionally renames 'title' to 'name' column<br> <li> Adds 'host_id' column with proper foreign key reference<br> <li> Migrates data from 'owner_id' to 'host_id' where needed<br> <li> Removes incorrect 'time' column from wrong schema<br> <li> Updates trigger and RLS policies for dual-column compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/12/files#diff-0200d42f55dd956bab548b925cd230ef086f6f2e72b665eb4478941dfb6b774e">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conflicting public.groups schemas to restore reliable group creation and consistent RLS behavior. Adds a safe migration and an immediate SQL patch to unify columns, repair triggers, and ensure backward compatibility at scale.

- **Bug Fixes**
  - Rename title to name and ensure name exists.
  - Add host_id (FK to auth.users); backfill from owner_id.
  - Add created_at (default NOW()); drop wrong time column.
  - Update add_group_owner trigger to COALESCE(host_id, owner_id).
  - Refresh RLS (insert/update/delete) to use COALESCE; keep select open.
  - Include a standalone SQL patch for urgent production fixes.

- **Migration**
  - Urgent: run fix_groups_schema_NOW.sql in Supabase SQL Editor if you need an immediate fix.
  - Standard: apply supabase/migrations/20251128_fix_groups_schema.sql via your migration pipeline.
  - Verify: host_id populated, trigger exists, policies present; smoke-test create/update/delete groups.
  - Safety/performance: changes are idempotent and backward compatible; FK uses ON DELETE SET NULL. Recommend indexing host_id and confirming group_members (group_id, user_id) composite index for scale.
  - Follow-ups: add NOT NULL to host_id after app rollout, deprecate owner_id, add schema-drift monitoring and audit logs. Alternative: use a compatibility view mapping owner_id→host_id before full deprecation.

<sup>Written for commit 6a0001ea7d8fee1e2bc4b350afa6414e9bac484c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized groups database structure for consistency and reliability.
  * Implemented automatic group owner assignment upon group creation.
  * Updated access control policies to ensure proper authorization for group management operations including creation, updates, and deletions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->