### PR TITLE
Fix: Add canUpdateOwnMetadata permission to LiveKit token

### DIFF
--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: NextRequest) {
       canPublish: true,
       canSubscribe: true,
       canPublishData: true,
+      canUpdateOwnMetadata: true,
     })
 
     const token = await at.toJwt()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `canUpdateOwnMetadata` permission to LiveKit token grants

- Enables users to update their own metadata in LiveKit sessions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LiveKit Token Grant"] -- "add permission" --> B["canUpdateOwnMetadata: true"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add canUpdateOwnMetadata permission to token grant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/livekit-token/route.ts

<ul><li>Added <code>canUpdateOwnMetadata: true</code> to the LiveKit token grant <br>permissions<br> <li> Enables users to update their own metadata within LiveKit rooms</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/22/files#diff-e1240a210c42da781f109d8353999fec8c617e52977470040d4b9e62159c4991">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canUpdateOwnMetadata to LiveKit token grants so participants can update their own metadata during sessions. Improves UX, reduces backend hops, and keeps permissions scoped to self-only updates.

- **Reliability, Safety, and Scale**
  - Scoped to self only; no room-wide privilege escalation.
  - Fewer backend calls; updates go via LiveKit signaling for better throughput at scale.
  - Guardrails: use short token TTLs, enforce metadata size/keys, and monitor ParticipantMetadataChanged rates.
  - Alternative: if compliance needs server mediation, remove this grant and proxy updates through a signed backend endpoint using the LiveKit Server SDK.

<sup>Written for commit d9dc426fe79b0c871b4d8f610a7e97de546b4f7b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

