### PR TITLE
feat: add TheHive security platform to Docker setup

### DIFF
--- a/cortex/application.conf
+++ b/cortex/application.conf
@@ -1,0 +1,41 @@
+# Cortex Configuration for SLTR
+# Documentation: https://github.com/TheHive-Project/CortexDocs
+
+# Play Framework Configuration
+play.http.secret.key = "changeme-generate-cortex-secret"
+
+# Elasticsearch Configuration
+search {
+  index = cortex
+  uri = "http://elasticsearch:9200"
+}
+
+# Job Directory
+job {
+  runner = [docker, process]
+  directory = "/opt/cortex/jobs"
+}
+
+# Cache Configuration
+cache.job = 10 minutes
+
+# Analyzer/Responder Configuration
+analyzer {
+  urls = [
+    "https://download.thehive-project.org/analyzers.json"
+  ]
+}
+
+responder {
+  urls = [
+    "https://download.thehive-project.org/responders.json"
+  ]
+}
+
+# Authentication
+auth {
+  provider = [local, key]
+
+  # Session timeout
+  ad.domainFQDN = "sltr.local"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,10 +66,103 @@ services:
     networks:
       - sltr-network
 
+  # ============================================
+  # TheHive Security Platform
+  # ============================================
+
+  # Elasticsearch (required by TheHive)
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
+    container_name: sltr-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    networks:
+      - sltr-network
+
+  # Cassandra (required by TheHive)
+  cassandra:
+    image: cassandra:4.1
+    container_name: sltr-cassandra
+    environment:
+      - CASSANDRA_CLUSTER_NAME=sltr-thehive
+      - HEAP_NEWSIZE=512M
+      - MAX_HEAP_SIZE=1024M
+    volumes:
+      - cassandra-data:/var/lib/cassandra
+    ports:
+      - "9042:9042"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+    networks:
+      - sltr-network
+
+  # TheHive - Security Incident Response Platform
+  thehive:
+    image: strangebee/thehive:5.2
+    container_name: sltr-thehive
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      cassandra:
+        condition: service_healthy
+    environment:
+      - JVM_OPTS=-Xms512m -Xmx1024m
+    volumes:
+      - thehive-data:/opt/thp/thehive/data
+      - ./thehive/application.conf:/etc/thehive/application.conf:ro
+    ports:
+      - "9000:9000"
+    restart: unless-stopped
+    networks:
+      - sltr-network
+
+  # Cortex - Analysis Engine (optional, for automated analysis)
+  cortex:
+    image: thehiveproject/cortex:3.1.7
+    container_name: sltr-cortex
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - job_directory=/opt/cortex/jobs
+    volumes:
+      - cortex-data:/opt/cortex/jobs
+      - ./cortex/application.conf:/etc/cortex/application.conf:ro
+    ports:
+      - "9001:9001"
+    restart: unless-stopped
+    networks:
+      - sltr-network
+
 networks:
   sltr-network:
     driver: bridge
 
 volumes:
   redis-data:
+    driver: local
+  elasticsearch-data:
+    driver: local
+  cassandra-data:
+    driver: local
+  thehive-data:
+    driver: local
+  cortex-data:
     driver: local

--- a/docs/THEHIVE_SETUP.md
+++ b/docs/THEHIVE_SETUP.md
@@ -1,0 +1,238 @@
+# TheHive Security Platform Setup
+
+## Overview
+
+TheHive is an open-source Security Incident Response Platform (SIRP) integrated with SLTR for security monitoring and incident management.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    SLTR Security Stack                       │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐  │
+│  │   TheHive    │◄──►│    Cortex    │◄──►│ Elasticsearch│  │
+│  │   :9000      │    │    :9001     │    │    :9200     │  │
+│  └──────────────┘    └──────────────┘    └──────────────┘  │
+│         │                                       ▲           │
+│         ▼                                       │           │
+│  ┌──────────────┐                              │           │
+│  │  Cassandra   │──────────────────────────────┘           │
+│  │    :9042     │                                          │
+│  └──────────────┘                                          │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Services
+
+| Service       | Port | Description                           |
+|---------------|------|---------------------------------------|
+| TheHive       | 9000 | Main incident response platform       |
+| Cortex        | 9001 | Automated analysis engine             |
+| Elasticsearch | 9200 | Search and indexing                   |
+| Cassandra     | 9042 | Graph database for case data          |
+
+## Quick Start
+
+### 1. Start the Security Stack
+
+```bash
+# Start all services (first run takes ~5-10 minutes for Cassandra)
+docker-compose up -d elasticsearch cassandra
+
+# Wait for Cassandra to be healthy (check with)
+docker-compose logs -f cassandra
+
+# Once Cassandra shows "Starting listening for CQL clients"
+docker-compose up -d thehive cortex
+```
+
+### 2. Initial Setup
+
+1. **Access TheHive**: http://localhost:9000
+2. **Default login**:
+   - Username: `admin@thehive.local`
+   - Password: `secret` (CHANGE THIS IMMEDIATELY)
+
+3. **First-time setup wizard** will guide you through:
+   - Creating an organization
+   - Setting up admin user
+   - Configuring Cortex connection
+
+### 3. Using Your Keychain Credentials
+
+Those credentials stored in macOS Keychain are TheHive API credentials:
+
+```
+Organization ID: 2baef15b-b8de-423f-9d8a-46f3686d8848
+API Key:         b16f28af-e873-46a9-9e44-b807e49137a1.2baef15b-b8de...
+```
+
+To retrieve and use them:
+
+```bash
+# View the stored credentials
+security find-generic-password -a "b16f28af-e873-46a9-9e44-b807e49137a1.2baef15b-b8de-423f-9d8a-46f3686d8848" -w
+
+# Or through Keychain Access app:
+# 1. Open Keychain Access
+# 2. Search for "2baef15b-b8de-423f-9d8a-46f3686d8848"
+# 3. Double-click > Show password
+```
+
+**Use in API calls:**
+```bash
+# Example: List cases in TheHive
+curl -H "Authorization: Bearer YOUR_API_KEY_HERE" \
+     http://localhost:9000/api/v1/case
+```
+
+### 4. Configure Cortex Connection
+
+1. Access Cortex: http://localhost:9001
+2. Create an organization
+3. Create an API key for TheHive integration
+4. Update `thehive/application.conf`:
+   ```
+   cortex.servers[0].auth.key = "your-cortex-api-key"
+   ```
+5. Restart TheHive: `docker-compose restart thehive`
+
+## Environment Variables
+
+Add to `.env.local`:
+
+```bash
+# TheHive Security Platform
+THEHIVE_URL=http://localhost:9000
+THEHIVE_API_KEY=your-thehive-api-key
+THEHIVE_ORG_ID=2baef15b-b8de-423f-9d8a-46f3686d8848
+
+# Cortex Analysis Engine
+CORTEX_URL=http://localhost:9001
+CORTEX_API_KEY=your-cortex-api-key
+```
+
+## Integration with SLTR
+
+### Automatic Incident Creation
+
+TheHive can receive security events from SLTR:
+
+```typescript
+// Example: Report security incident
+async function reportIncident(event: SecurityEvent) {
+  const response = await fetch(`${process.env.THEHIVE_URL}/api/v1/case`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.THEHIVE_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      title: event.title,
+      description: event.description,
+      severity: event.severity,  // 1-4
+      tlp: 2,  // Traffic Light Protocol
+      tags: ['sltr', 'automated']
+    })
+  })
+  return response.json()
+}
+```
+
+### Security Events to Track
+
+| Event Type          | Severity | Auto-create Case |
+|---------------------|----------|------------------|
+| Multiple failed logins | 2     | Yes              |
+| Account lockout     | 2        | Yes              |
+| Suspicious IP       | 3        | Yes              |
+| Data export attempt | 3        | Yes              |
+| Admin action        | 1        | No (log only)    |
+| User report         | 2        | Yes              |
+
+## Maintenance
+
+### Backup
+
+```bash
+# Backup TheHive data
+docker-compose exec cassandra cqlsh -e "DESCRIBE KEYSPACE thehive" > backup/thehive-schema.cql
+docker-compose exec cassandra nodetool snapshot thehive
+
+# Backup Elasticsearch
+curl -X PUT "localhost:9200/_snapshot/backup/snapshot_$(date +%Y%m%d)"
+```
+
+### Update
+
+```bash
+# Pull latest images
+docker-compose pull thehive cortex elasticsearch cassandra
+
+# Restart with new images
+docker-compose up -d
+```
+
+### Logs
+
+```bash
+# View TheHive logs
+docker-compose logs -f thehive
+
+# View Cortex logs
+docker-compose logs -f cortex
+
+# View all security stack logs
+docker-compose logs -f thehive cortex elasticsearch cassandra
+```
+
+## Troubleshooting
+
+### Cassandra Won't Start
+```bash
+# Check memory (Cassandra needs ~2GB)
+docker stats
+
+# If low on memory, reduce heap in docker-compose.yml:
+# MAX_HEAP_SIZE=512M
+```
+
+### TheHive Can't Connect to Cassandra
+```bash
+# Verify Cassandra is healthy
+docker-compose exec cassandra cqlsh -e "DESCRIBE KEYSPACES"
+
+# Check TheHive logs
+docker-compose logs thehive | grep -i cassandra
+```
+
+### Cortex Analyzers Not Working
+```bash
+# Verify Docker socket is accessible
+docker-compose exec cortex docker ps
+
+# Enable Docker-in-Docker if needed
+# Add to cortex service in docker-compose.yml:
+# volumes:
+#   - /var/run/docker.sock:/var/run/docker.sock
+```
+
+## Security Notes
+
+1. **Change default passwords** immediately after setup
+2. **Generate proper secrets** for `play.http.secret.key` in both configs:
+   ```bash
+   openssl rand -hex 32
+   ```
+3. **Restrict network access** - TheHive should not be publicly accessible
+4. **Enable TLS** for production deployments
+5. **Regular backups** - Cassandra data is critical
+
+## Resources
+
+- [TheHive Documentation](https://docs.strangebee.com/thehive/)
+- [Cortex Documentation](https://github.com/TheHive-Project/CortexDocs)
+- [TheHive API Reference](https://docs.strangebee.com/thehive/api-docs/)

--- a/thehive/application.conf
+++ b/thehive/application.conf
@@ -1,0 +1,66 @@
+# TheHive 5.x Configuration for SLTR
+# Documentation: https://docs.strangebee.com/thehive/
+
+# Play Framework Configuration
+play.http.secret.key = "changeme-generate-a-secret-key"
+
+# Database Configuration - Cassandra
+db.janusgraph {
+  storage {
+    backend = cql
+    hostname = ["cassandra"]
+    cql {
+      cluster-name = sltr-thehive
+      keyspace = thehive
+    }
+  }
+  index.search {
+    backend = elasticsearch
+    hostname = ["elasticsearch"]
+    index-name = thehive
+  }
+}
+
+# Storage Configuration
+storage {
+  provider = localfs
+  localfs.location = /opt/thp/thehive/data
+}
+
+# Cortex Integration (for automated analysis)
+play.modules.enabled += org.thp.thehive.connector.cortex.CortexModule
+cortex {
+  servers = [
+    {
+      name = "SLTR-Cortex"
+      url = "http://cortex:9001"
+      auth {
+        type = "bearer"
+        # Set this to your Cortex API key after initial setup
+        key = "CORTEX_API_KEY_HERE"
+      }
+    }
+  ]
+}
+
+# Authentication Configuration
+auth {
+  providers = [
+    {name: session}
+    {name: basic, realm: thehive}
+    {name: local}
+    {name: key}
+  ]
+
+  # Initial admin account (change password after first login!)
+  defaultUserDomain = "sltr.local"
+}
+
+# Application Settings
+application.baseUrl = "http://localhost:9000"
+
+# Streaming/SSE Configuration
+stream.longPolling.refresh = 1 minute
+stream.longPolling.cache = 15 minutes
+stream.longPolling.nextItemMaxWait = 500 millis
+stream.longPolling.globalMaxWait = 1 second


### PR DESCRIPTION
### **User description**
- Add TheHive 5.2 SIRP to docker-compose.yml
- Add Cortex 3.1.7 analysis engine
- Add Elasticsearch 7.17.9 for indexing
- Add Cassandra 4.1 for graph database
- Create TheHive application.conf with Cassandra/ES config
- Create Cortex application.conf with analyzer/responder config
- Add THEHIVE_SETUP.md documentation with API credentials usage


___

### **PR Type**
Enhancement


___

### **Description**
- Integrate TheHive 5.2 SIRP with Cortex 3.1.7 analysis engine

- Add Elasticsearch 7.17.9 and Cassandra 4.1 database services

- Create configuration files for TheHive and Cortex platforms

- Add comprehensive setup documentation with API integration guide


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SLTR Security Stack"] --> B["TheHive 5.2<br/>Port 9000"]
  A --> C["Cortex 3.1.7<br/>Port 9001"]
  A --> D["Elasticsearch 7.17.9<br/>Port 9200"]
  A --> E["Cassandra 4.1<br/>Port 9042"]
  B --> D
  B --> E
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add TheHive security platform services to Docker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Add Elasticsearch service with single-node configuration and health <br>checks<br> <li> Add Cassandra service with cluster setup and persistent volumes<br> <li> Add TheHive service with dependencies on Elasticsearch and Cassandra<br> <li> Add Cortex service with Elasticsearch dependency<br> <li> Define new volumes for elasticsearch-data, cassandra-data, <br>thehive-data, cortex-data</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/70/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application.conf</strong><dd><code>Configure TheHive application settings and integrations</code>&nbsp; &nbsp; </dd></summary>
<hr>

thehive/application.conf

<ul><li>Configure JanusGraph database backend with Cassandra storage<br> <li> Set Elasticsearch as search backend for indexing<br> <li> Configure local filesystem storage for case data<br> <li> Integrate Cortex server with bearer token authentication<br> <li> Define authentication providers including session, basic, local, and <br>key-based<br> <li> Set application base URL and streaming configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/70/files#diff-d91ad9f330ab87401090c10bd90a1eecd5628fc9e70088124002817f9b2bb145">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application.conf</strong><dd><code>Configure Cortex analysis engine settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cortex/application.conf

<ul><li>Configure Elasticsearch connection for job indexing<br> <li> Set job runner to support Docker and process execution<br> <li> Configure analyzer and responder URLs from TheHive project<br> <li> Define authentication providers with local and key-based methods<br> <li> Set cache timeout for job execution</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/70/files#diff-0b51ea11ce5f534e18d21a3eb6812f20d0ad7a487e103c051e28c411d3a595e4">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>THEHIVE_SETUP.md</strong><dd><code>Add comprehensive TheHive setup and integration documentation</code></dd></summary>
<hr>

docs/THEHIVE_SETUP.md

<ul><li>Document TheHive architecture with service diagram and port mappings<br> <li> Provide quick start guide for deploying and initializing services<br> <li> Include instructions for using macOS Keychain stored API credentials<br> <li> Document Cortex connection configuration and API integration<br> <li> Add environment variables configuration for THEHIVE_URL, API_KEY, and <br>ORG_ID<br> <li> Provide TypeScript example for automatic incident creation from SLTR <br>events<br> <li> Include security event tracking table with severity levels<br> <li> Document backup, update, and troubleshooting procedures<br> <li> List security best practices including password changes and TLS <br>enablement</ul>


</details>


  </td>
  <td><a href="https://github.com/get-sltr/3musketeers/pull/70/files#diff-026fc69ff5d65a3d1dbc06814c9f46178a618bf58a0df7b268aec721c92ba894">+238/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TheHive 5.2 with Cortex 3.1.7 to our Docker stack, backed by Elasticsearch and Cassandra, to deliver a reliable, safe, and scalable incident-response platform. Includes hardened configs, health checks, persistent storage, and setup docs for enterprise-ready operations.

- **New Features**
  - Docker services for TheHive, Cortex, Elasticsearch 7.17.9, and Cassandra 4.1 with health checks and restart policies.
  - TheHive and Cortex application.conf files wired to Cassandra/Elasticsearch, analyzers/responders, and auth providers (with secret placeholders).
  - Persistent volumes and resource tuning (ES JVM opts, Cassandra heap) for stable, predictable performance.
  - THEHIVE_SETUP.md covering setup, API usage, SLTR integration, backups, updates, and troubleshooting.

- **Migration**
  - Generate real Play secrets, change default admin password, restrict ports, and enable TLS before exposing services.
  - Right-size memory for Cassandra/Elasticsearch (dev defaults included); increase heaps and consider dedicated nodes for production.
  - Create Cortex org and API key, set it in thehive/application.conf, then restart TheHive to enable automated analysis.
  - If analyzers require Docker, mount /var/run/docker.sock in Cortex or switch to process runner for stricter isolation.
  - Establish regular backups (Cassandra snapshots, ES repo) and monitor container health; for scale or licensing needs, consider OpenSearch 2.x and managed ES/Cassandra.

<sup>Written for commit d409ef7c5bb2877299982cb3c488b1b12ab32b63. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated TheHive Security Platform for comprehensive threat management and case handling
  * Added Cortex analyzer integration for security analysis
  * Configured complete Docker Compose stack with all required services (Elasticsearch, Cassandra, TheHive, Cortex)

* **Documentation**
  * Added detailed TheHive setup guide covering architecture, quick-start instructions, troubleshooting, and maintenance procedures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->